### PR TITLE
Closes #7 - Give all containers more vCPU and memory

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -156,7 +156,7 @@ const frontendService = new awsx.classic.ecs.FargateService("service", {
     container: {
       image: frontendImage.imageUri,
       cpu: 512,
-      memory: 128,
+      memory: 1024,
       essential: true,
       portMappings: [listener],
       environment: [
@@ -186,7 +186,7 @@ const pelicanService = new awsx.classic.ecs.FargateService("pelican-service", {
     container: {
       image: pelicanImage.imageUri,
       cpu: 512,
-      memory: 128,
+      memory: 1024,
       essential: true,
       environment: [
         { name: "POSTGRES_DB_NAME", value: process.env.POSTGRES_DB_NAME as string },
@@ -217,8 +217,8 @@ const emuService = new awsx.classic.ecs.FargateService("emu-service", {
   taskDefinitionArgs: {
     container: {
       image: emuImage.imageUri,
-      cpu: 512,
-      memory: 128,
+      cpu: 4096,
+      memory: 8192,
       essential: true,
       environment: [
         { name: "PINECONE_INDEX", value: process.env.PINECONE_INDEX as string },


### PR DESCRIPTION
## Problem

Closes #7 

Describe the purpose of this change. What problem is being solved and why?

We started out with minimal allocations for all ECS service containers, but now we want to right-size them for production usage. 

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

Gave all containers more virtual CPU and memory, with Emu getting the most since it's doing the most heavy lifting while embedding and upserting, and because it uses a worker pool pattern keyed off the number of CPUs available.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

Ensure containers come up healthy and work properly following this resource allocation increase.