### PR TITLE
Check for required environment variables on startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,13 @@
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
+import checkEnvVars from "./utils"
 
 // Context: see https://www.notion.so/AWS-Pinecone-Reference-Architecture-in-Pulumi-PRD-61245ccff1f040499b5e2417f92eee77
+//
+
+// Sanity check that all required environment variables are defined, and error 
+// out with a helpful message about which ones are unset if not
+checkEnvVars();
 
 /**
  * Networking

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,20 @@
+export default function checkEnvVars() {
+  const requiredEnvVars = [
+    "PINECONE_API_KEY",
+    "PINECONE_ENVIRONMENT",
+    "PINECONE_INDEX",
+    "PINECONE_NAMESPACE",
+    "POSTGRES_DB_PASSWORD",
+    "AWS_REGION",
+  ];
+
+  const missingEnvVars = requiredEnvVars.filter(
+    (envVar) => !process.env[envVar],
+  );
+
+  if (missingEnvVars.length > 0) {
+    throw new Error(
+      `Missing required environment variables: ${missingEnvVars.join(", ")}`,
+    );
+  }
+}


### PR DESCRIPTION
## Problem

Describe the purpose of this change. What problem is being solved and why?

If the user fails to set the required environment variables, certain services will fail. These changes implement a simple check for an array of required environment variables. 

If any of the variables are not set, the `pulumi up` command will fail and terminate execution with a human-legible error explaining which variables need to be set.

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

Add a simple function that checks for required env vars similar to how Pelican does. 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

Tested locally and confirmed that running `pulumi up` without the required env vars set results in the human-legible error, whereas running `pulumi up` with all required env vars set proceeds normally.
