### PR TITLE
Update RDS Snapshot - includes latest schema changes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -161,7 +161,7 @@ const rdsSecurityGroup = new aws.ec2.SecurityGroup("rdsSecurityGroup", {
 const db = new aws.rds.Instance("mydb", {
   // This RDS snapshot has the products_with_increment table already created and is populated with the data from 
   // data/products_no_ids.csv
-  snapshotIdentifier: "arn:aws:rds:us-east-1:675304494746:snapshot:pinecone-aws-ref-arch-postgres-db-snapshot",
+  snapshotIdentifier: "arn:aws:rds:us-east-1:675304494746:snapshot:pinecone-aws-refarch-postgres-snapshot-v2",
   dbSubnetGroupName: dbSubnetGroup.name,
   engine: "postgres",
   engineVersion: "15.4",


### PR DESCRIPTION
## Problem

This change updates the RefArch to use the latest public RDS Postgres snapshot, which contains the latest schema changes made to support Pelican's data bootstrapping init routine (locks table). 

## Solution

This PR updates the snapshot identifier to the latest version.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

This will be verified in the live AWS RefArch.
