### PR TITLE
Simplify required env vars to streamline setup

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -3,8 +3,6 @@ export default function checkEnvVars() {
     "PINECONE_API_KEY",
     "PINECONE_ENVIRONMENT",
     "PINECONE_INDEX",
-    "POSTGRES_DB_PASSWORD",
-    "AWS_REGION",
   ];
 
   const missingEnvVars = requiredEnvVars.filter(


### PR DESCRIPTION
## Problem

We have an opportunity to reduce the setup process to require only three environment variables from Pinecone before running `pulumi up`.

## Solution

Simplify setup by reducing the environment variables required from the user. The RDS Snapshot that the RefArch uses has the same password, which is fine because it only contains fake products data and runs in a private subnet, so we don't need the user to set anything there. 

AWS_REGION can now be set, or it will default to `us-east-1`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

These changes were verified with a fresh deployment of the Reference Architecture.
