### PR TITLE
updated FROM to use the -slim version

### DIFF
--- a/emu/Dockerfile
+++ b/emu/Dockerfile
@@ -1,5 +1,5 @@
 # Use an ARM64 compatible Node.js runtime as a parent image
-FROM node:20.0.0
+FROM node:20.0.0-slim
 
 # Set the working directory to /app-backend
 WORKDIR /app

--- a/pelican/Dockerfile
+++ b/pelican/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the TypeScript application
-FROM node:20.0.0 AS builder
+FROM node:20.0.0-slim AS builder
 
 WORKDIR /usr/src/app
 
@@ -19,7 +19,7 @@ COPY . .
 RUN npm run build
 
 # Stage 2: Run the compiled JavaScript
-FROM node:20.0.0
+FROM node:20.0.0-slim
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Problem

The Docker images being used take a long time to get pushed. See #57 

## Solution

Uses slim images for faster total build time when bringing up the reference architecture.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.

Successfully run `pulumi up -y`
