### PR TITLE
Use ANY to query Postgres IDs correctly

### DIFF
--- a/semantic-search-postgres/src/app/api/products/route.js
+++ b/semantic-search-postgres/src/app/api/products/route.js
@@ -57,7 +57,7 @@ async function handler(req) {
     action: "pinecone_query_results",
   });
 
-  const ids = result ? result.matches?.map((match) => match.metadata?.id) : [];
+  const ids = result ? result.matches?.map((match) => Number(match.metadata?.id)) : [];
 
   console.log(`ids before query: ${ids}`)
 
@@ -71,7 +71,7 @@ async function handler(req) {
 
   const productsQuery = `
     SELECT * FROM products_with_increment
-    ${ids.length > 0 ? `WHERE id IN ($1)` : ''}
+    ${ids.length > 0 ? `WHERE id = ANY ($1)` : ''}
     LIMIT ${limit} OFFSET ${offset}
   `;
   const params = [];


### PR DESCRIPTION
## Problem

The frontend app is throwing an error when attempting to use the `IN` operator with the flat array of Postgres record IDs.

## Solution

Use the `ANY` operator which will accept a flat array as a param.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

This change was verified against the live ref arch.
