### PR TITLE
Upgrade Pinecone client to spruce branch

### DIFF
--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -1,3 +1,2 @@
 name: ratest
 runtime: nodejs
-description: A Ref Arch test

--- a/emu/package.json
+++ b/emu/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.445.0",
-    "@pinecone-database/pinecone": "^1.1.1",
+    "@pinecone-database/pinecone": "1.1.2-spruceDev.20240105000833",
     "@types/express": "^4.17.19",
     "@types/node": ">= 14",
     "@xenova/transformers": "^2.6.2",

--- a/emu/pnpm-lock.yaml
+++ b/emu/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^3.445.0
     version: 3.445.0
   '@pinecone-database/pinecone':
-    specifier: ^1.1.1
-    version: 1.1.1
+    specifier: 1.1.2-spruceDev.20240105000833
+    version: 1.1.2-spruceDev.20240105000833
   '@types/express':
     specifier: ^4.17.19
     version: 4.17.19
@@ -782,18 +782,6 @@ packages:
       kuler: 2.0.0
     dev: false
 
-  /@edge-runtime/primitives@4.0.2:
-    resolution: {integrity: sha512-zIzzqvq62O0gxKv/PrfFBn2TEJtJYw6YlNyfLsWr16Lxz6bT8CB1IrfWa9vc5zsQPElP/orwZCu+x80+ihWQyQ==}
-    engines: {node: '>=16'}
-    dev: false
-
-  /@edge-runtime/types@2.2.4:
-    resolution: {integrity: sha512-w2DrfkLW4C/r5lpjsICc76qGX++sNvnN8sYeqXsTSpWInc8+3unofGsDUw4w34T7zQ7Mmcyld04qiLIrNoz+fQ==}
-    engines: {node: '>=16'}
-    dependencies:
-      '@edge-runtime/primitives': 4.0.2
-    dev: false
-
   /@esbuild/android-arm64@0.18.20:
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -1132,17 +1120,14 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@pinecone-database/pinecone@1.1.1:
-    resolution: {integrity: sha512-8af+2fAAkkHC1BIe+op8Tk4YLvJYK1qM2ITuwVmFdNVcHG6oHdXlZdR8GGdOLfYSVuLf4aZid7xhjYUSBqux8Q==}
+  /@pinecone-database/pinecone@1.1.2-spruceDev.20240105000833:
+    resolution: {integrity: sha512-zktN/sl2vqsh+pMyoiK8zV7/oPXTi4QUQlbLnEyIu8XQBtHeNYSmloZX2FhBbQ0Ls9GzSwKakKd3F4xn7bjIqw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@edge-runtime/types': 2.2.4
       '@sinclair/typebox': 0.29.6
-      '@types/node': 18.18.5
       ajv: 8.12.0
       cross-fetch: 3.1.8(encoding@0.1.13)
       encoding: 0.1.13
-      typescript: 4.9.5
     dev: false
 
   /@protobufjs/aspromise@1.1.2:
@@ -1637,10 +1622,6 @@ packages:
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
-
-  /@types/node@18.18.5:
-    resolution: {integrity: sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==}
-    dev: false
 
   /@types/node@20.8.6:
     resolution: {integrity: sha512-eWO4K2Ji70QzKUqRy6oyJWUeB7+g2cRagT3T/nxYibYcT4y2BDL8lqolRXjTHmkZCdJfIPaY73KbJAZmcryxTQ==}
@@ -5061,12 +5042,6 @@ packages:
       for-each: 0.3.3
       is-typed-array: 1.1.12
     dev: true
-
-  /typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: false
 
   /typescript@5.1.6:
     resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}

--- a/emu/src/orchestrator.ts
+++ b/emu/src/orchestrator.ts
@@ -23,7 +23,7 @@ if (!indexName) {
   throw new Error("environment variable PINECONE_INDEX must be set");
 }
 
-const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY });
+const pinecone = new Pinecone({ apiKey: String(process.env.PINECONE_API_KEY) });
 
 const numCPUs = os.cpus().length;
 

--- a/emu/src/orchestrator.ts
+++ b/emu/src/orchestrator.ts
@@ -23,7 +23,7 @@ if (!indexName) {
   throw new Error("environment variable PINECONE_INDEX must be set");
 }
 
-const pinecone = new Pinecone();
+const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY });
 
 const numCPUs = os.cpus().length;
 

--- a/emu/src/testPinecone.ts
+++ b/emu/src/testPinecone.ts
@@ -1,7 +1,7 @@
 import { Pinecone } from "@pinecone-database/pinecone";
 import { v4 as uuidv4 } from "uuid";
 
-const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY });
+const pinecone = new Pinecone({ apiKey: String(process.env.PINECONE_API_KEY) });
 
 const indexName = process.env.PINECONE_INDEX;
 const namespace = process.env.PINECONE_NAMESPACE;

--- a/emu/src/testPinecone.ts
+++ b/emu/src/testPinecone.ts
@@ -1,7 +1,7 @@
 import { Pinecone } from "@pinecone-database/pinecone";
 import { v4 as uuidv4 } from "uuid";
 
-const pinecone = new Pinecone();
+const pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY });
 
 const indexName = process.env.PINECONE_INDEX;
 const namespace = process.env.PINECONE_NAMESPACE;

--- a/index.ts
+++ b/index.ts
@@ -6,12 +6,10 @@ import * as awsx from "@pulumi/awsx";
 import { makeSsmParameterSecrets } from './secrets'
 
 const config = new pulumi.Config();
+
 const AWS_REGION = aws.config.requireRegion();
-
 const PINECONE_API_KEY = config.requireSecret("PINECONE_API_KEY");
-const PINECONE_ENVIRONMENT = config.require("PINECONE_ENVIRONMENT");
 const PINECONE_INDEX = config.require("PINECONE_INDEX");
-
 const PELICAN_BATCH_SIZE = config.getNumber("PELICAN_BATCH_SIZE") ?? 1000;
 
 // Context: see https://www.notion.so/AWS-Pinecone-Reference-Architecture-in-Pulumi-PRD-61245ccff1f040499b5e2417f92eee77
@@ -369,15 +367,15 @@ const sqsReadAndDeletePolicy = new aws.iam.Policy(
 
 const ecsEmuTaskRole = new aws.iam.Role("ecs-emu-task-execution-role", {
   assumeRolePolicy: {
-        "Version": "2012-10-17",
-        "Statement": [{
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "ecs-tasks.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole"
-        }]
-    }
+    "Version": "2012-10-17",
+    "Statement": [{
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }]
+  }
 });
 
 new aws.iam.RolePolicyAttachment("sqs-read-and-delete-policy-attachment", {
@@ -469,8 +467,8 @@ const frontendService = new awsx.ecs.FargateService("frontend-service", {
         POSTGRES_DB_PASSWORD: dbSnapshotPassword,
       }),
       environment: [
+        { name: "AWS_REGION", value: AWS_REGION },
         { name: "HOSTNAME", value: "0.0.0.0" },
-        { name: "PINECONE_ENVIRONMENT", value: PINECONE_ENVIRONMENT },
         { name: "PINECONE_INDEX", value: PINECONE_INDEX },
         { name: "POSTGRES_DB_NAME", value: 'postgres' },
         // Pass in the hostname and port of the RDS Postgres instance so the frontend knows where to find it
@@ -564,7 +562,6 @@ const emuService = new awsx.ecs.FargateService("emu-service", {
         PINECONE_API_KEY: PINECONE_API_KEY,
       }),
       environment: [
-        { name: "PINECONE_ENVIRONMENT", value: PINECONE_ENVIRONMENT },
         { name: "PINECONE_INDEX", value: PINECONE_INDEX },
         { name: "AWS_REGION", value: AWS_REGION },
         { name: "SQS_QUEUE_URL", value: jobQueueUrl }

--- a/semantic-search-postgres/Dockerfile
+++ b/semantic-search-postgres/Dockerfile
@@ -40,7 +40,6 @@ FROM base AS runner
 WORKDIR /app
 
 ENV PINECONE_API_KEY=$PINECONE_API_KEY
-ENV PINECONE_ENVIRONMENT=$PINECONE_ENVIRONMENT
 
 ENV NODE_ENV production
 # Uncomment the following line in case you want to disable telemetry during runtime.

--- a/semantic-search-postgres/__tests__/products.test.ts
+++ b/semantic-search-postgres/__tests__/products.test.ts
@@ -21,7 +21,13 @@ jest.mock('../src/app/api/products/pipeline', () => {
 });
 
 jest.mock('../src/app/api/products/pinecone', () => ({
-  getPinecone: jest.fn().mockResolvedValue({}),
+  getPinecone: jest.fn(() => ({
+    index: jest.fn(() => ({
+      namespace: jest.fn().mockReturnValue({
+        query: jest.fn().mockResolvedValue({ matches: [] }),
+      })
+    }))
+  })),
   getNamespace: jest.fn().mockResolvedValue({
     query: jest.fn().mockResolvedValue({ matches: [] }),
   }),

--- a/semantic-search-postgres/package-lock.json
+++ b/semantic-search-postgres/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@babel/preset-react": "^7.23.3",
         "@babel/preset-typescript": "^7.23.3",
-        "@pinecone-database/pinecone": "^1.1.2",
+        "@pinecone-database/pinecone": "^1.1.2-spruceDev.20240103000817",
         "@xenova/transformers": "^2.7.0",
         "next": "^13.5.4",
         "pg": "^8.11.3",
@@ -2084,25 +2084,6 @@
         "kuler": "^2.0.0"
       }
     },
-    "node_modules/@edge-runtime/primitives": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.0.5.tgz",
-      "integrity": "sha512-t7QiN5d/KpXgCvIfSt6Nm9Hj3WVdNgc5CpOD73jasY+9EvTI7Ngdj5cXvjcHrPcmYWJZMySPgeEeoL/1N/Llag==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@edge-runtime/types": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@edge-runtime/types/-/types-2.2.7.tgz",
-      "integrity": "sha512-9MTwGooICP7+ZsX9BTy6YCRzOr4tP6RFRymsc8CaKORfvuAHgLZUQaLwILfQ94tddufVXcBwq637VfEd3ZXbWA==",
-      "dependencies": {
-        "@edge-runtime/primitives": "4.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -2839,28 +2820,17 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.2.tgz",
-      "integrity": "sha512-xrvaMWWloTjT70pSxvw+Es2f7qX5lzhtTZBfduagtwGQqK0nFMqS6Jq+1yqzobDaUhqfRfVwRZ95Gm10odqD3Q==",
+      "version": "1.1.2-spruceDev.20240103000817",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.2-spruceDev.20240103000817.tgz",
+      "integrity": "sha512-zAetEKaiqKJaiw8ejB3E1/P5XcEFULUp+qVuszzuuVeuqi5gugo+E2wv3USe6L1MieX9cdRQ3r8w/0lmYOSu3A==",
       "dependencies": {
-        "@edge-runtime/types": "^2.2.3",
         "@sinclair/typebox": "^0.29.0",
-        "@types/node": "^18.11.17",
         "ajv": "^8.12.0",
         "cross-fetch": "^3.1.5",
-        "encoding": "^0.1.13",
-        "typescript": "^4.9.4"
+        "encoding": "^0.1.13"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@pinecone-database/pinecone/node_modules/@types/node": {
-      "version": "18.18.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.8.tgz",
-      "integrity": "sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "node_modules/@pinecone-database/pinecone/node_modules/ajv": {
@@ -2882,18 +2852,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-    },
-    "node_modules/@pinecone-database/pinecone/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",

--- a/semantic-search-postgres/package.json
+++ b/semantic-search-postgres/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@babel/preset-react": "^7.23.3",
     "@babel/preset-typescript": "^7.23.3",
-    "@pinecone-database/pinecone": "^1.1.2",
+    "@pinecone-database/pinecone": "^1.1.2-spruceDev.20240103000817",
     "@xenova/transformers": "^2.7.0",
     "next": "^13.5.4",
     "pg": "^8.11.3",

--- a/semantic-search-postgres/src/app/api/products/pinecone.js
+++ b/semantic-search-postgres/src/app/api/products/pinecone.js
@@ -2,54 +2,23 @@ import { Pinecone } from '@pinecone-database/pinecone';
 import logger from '../../logger';
 import worker_id from '../../workerIdSingleton'
 
+let indexSetup = false;
+
 /** @type Pinecone */
 let pinecone;
 export function getPinecone() {
   if (pinecone) {
     return pinecone;
   }
-  pinecone = new Pinecone({
-    apiKey: process.env.PINECONE_API_KEY,
-    environment: process.env.PINECONE_ENVIRONMENT,
-  });
+  pinecone = new Pinecone({ apiKey: process.env.PINECONE_API_KEY });
+  // If the index hasn't already been set up (e.g., created if it does not already exist)
+  // then create it via the Pinecone client
+  if (!indexSetup) {
+    setupIndex(pinecone, process.env.PINECONE_INDEX).then(() => {
+      indexSetup = true
+    })
+  }
   return pinecone;
-}
-
-let setupPromise;
-/**
- *
- * @param {Pinecone} pinecone
- * @param {string} indexName
- * @returns {Promise<Pinecone.Index>}
- */
-export async function getNamespace(pinecone, indexName) {
-  // Memoize setting up the index, but only if it succeeds.
-  if (!setupPromise) {
-    // No race condition here: Node.js is single-threaded and we assign to setupPromise after checking
-    // its value, with no awaits in between.
-    setupPromise = new Promise(async (resolve) => {
-      resolve(await setupIndex(pinecone, indexName));
-    });
-  }
-
-  const indexReady = await setupPromise;
-
-  if (!indexReady) {
-    // On failure, reset state and try again on the next request.
-    setupPromise = null;
-    logger.error({
-      message: "Index not ready",
-      service: "frontend",
-      worker_id,
-      action: "index_not_ready",
-    });
-    throw new Error("Index not ready");
-  }
-
-  // Intentionally use the default namespace for Pinecone
-  // The Emu microservice correlatively upserts to the default namespace,
-  // signified by ''
-  return pinecone.index(indexName).namespace('');
 }
 
 /**
@@ -60,31 +29,9 @@ export async function getNamespace(pinecone, indexName) {
  * @returns {boolean}
  */
 async function setupIndex(pinecone, indexName) {
-  logger.info({
-    message: "Listing indices",
-    service: "frontend",
-    worker_id,
-    action: "listing_indices",
-  });
-  const indices = await pinecone.listIndexes();
-
-  const indexExists = indices.some((index) => index.name === indexName);
-
-  logger.info({
-    message: "Finding index",
-    indexExists,
-    service: "frontend",
-    worker_id,
-    action: "finding_index",
-  });
-
-  if (indexExists) {
-    return true;
-  }
-
   try {
     logger.info({
-      message: "Creating index",
+      message: "Creating Pinecone index if necessary",
       service: "frontend",
       worker_id,
       action: "creating_index",
@@ -93,12 +40,15 @@ async function setupIndex(pinecone, indexName) {
     await pinecone.createIndex({
       name: indexName,
       dimension: 384,
+      // This option tells the client not to throw if the index already exists.
       suppressConflicts: true,
+      // This option tells the client not to resolve the promise until the
+      // index is ready.
       waitUntilReady: true,
-      metric: 'cosine'
+      metric: 'cosine',
+      spec: { serverless: { cloud: 'aws', region: process.env.AWS_REGION } }
     });
 
-    return true;
   } catch (err) {
     logger.error({
       message: "Error creating index",
@@ -107,7 +57,5 @@ async function setupIndex(pinecone, indexName) {
       worker_id,
       action: "error_creating_index",
     });
-
-    return false;
   }
 }

--- a/semantic-search-postgres/src/app/api/products/route.js
+++ b/semantic-search-postgres/src/app/api/products/route.js
@@ -3,7 +3,7 @@ import PipelineSingleton from './pipeline.js';
 import { NextResponse } from 'next/server'
 import logger from '../../logger';
 import worker_id from '../../workerIdSingleton'
-import { getPinecone, getNamespace } from './pinecone.js';
+import { getPinecone } from './pinecone.js';
 
 // This cannot be served at build time.
 export const dynamic = 'force-dynamic';
@@ -15,12 +15,12 @@ async function handler(req) {
 
   const pinecone = getPinecone();
 
-  console.log(`searchTerm: ${searchTerm}, currentPage: ${currentPage}`);
-
   logger.info({
     message: "Products route hit",
     service: "frontend",
     worker_id,
+    searchTerm,
+    currentPage,
     action: "products_route_handler",
   });
 

--- a/semantic-search-postgres/src/app/api/products/route.js
+++ b/semantic-search-postgres/src/app/api/products/route.js
@@ -26,9 +26,7 @@ async function handler(req) {
 
   const offset = currentPage > 1 ? (currentPage - 1) * limit : 0;
 
-  const indexName = process.env.PINECONE_INDEX;
-
-  const namespace = await getNamespace(pinecone, indexName);
+  const namespace = pinecone.index(process.env.PINECONE_INDEX).namespace('');
 
   const classifier = await PipelineSingleton.getInstance();
 


### PR DESCRIPTION
## Problem

We need to update the AWS Reference Architecture to use the latest "spruce" branch of the Pinecone TypeScript client.

## Solution

Simplified some of the setup / createIndex code, and upgraded to the `spruce` branch, making the necessary signature changes and dropping `PINECONE_ENVIRONMENT`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

This will be verified in a fresh deployment of the AWS Ref Arch
