### PR TITLE
Add Pulumi install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ pulumi config set --secret PINECONE_API_KEY "$PINECONE_API_KEY"
 pulumi config set PINECONE_INDEX "$PINECONE_INDEX"
 ```
 
-7. **Initialize and Run Pulumi Stack**
+7. **Install SDK Dependencies**
+
+    * Run `pulumi install` to install the required dependencies.
+
+8. **Initialize and Run Pulumi Stack**
 
     * Deploy Resources: Execute `pulumi up` to start the deployment.
     * Review and Confirm: Review the Pulumi preview of resources to be created. Confirm by selecting `Yes` to proceed.


### PR DESCRIPTION
## Problem

The dependency install step is currently missing from the Quickstart guide.

## Solution

Add the `pulumi install` step to the Quickstart section of the README.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [x] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Change is verified through several test deployments.
